### PR TITLE
tag manifest.json with release number

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,28 +1,35 @@
-name: "Publish"
+# Triggered by bare semver tags pushed from scripts/bump-version.sh.
+# Tags must not have a "v" prefix (e.g. 0.6.0, not v0.6.0).
+# The manifest.json version is already set by the script, so no
+# build-time patching is needed — the zip is built from the repo as-is.
+name: Release
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+*"
+
+permissions:
+  contents: write
 
 jobs:
-  publish:
-    name: "Publish"
+  release:
+    name: Create Release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: "Update version"
+      - name: Zip component
         run: |
-          yq -i -o json '.version="${{ github.event.release.tag_name }}"' "${{ github.workspace }}/custom_components/additional_ca/manifest.json"
+          cd custom_components/additional_ca
+          zip "$GITHUB_WORKSPACE/additional_ca.zip" -r ./
 
-      - name: "Zip component"
-        run: |
-          cd "${{ github.workspace }}/custom_components/additional_ca"
-          zip "${{ github.workspace }}/additional_ca.zip" -r ./
-
-      - name: "Upload assets"
+      - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload ${{ github.event.release.tag_name }} "${{ github.workspace }}/additional_ca.zip"
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes \
+            additional_ca.zip

--- a/custom_components/additional_ca/manifest.json
+++ b/custom_components/additional_ca/manifest.json
@@ -13,5 +13,5 @@
     "aiofiles==24.1.0",
     "certifi-linux==1.1.0"
   ],
-  "version": "0.0.0"
+  "version": "0.5.1"
 }

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+# Release flow:
+#   1. This script stamps the version into manifest.json and commits it,
+#      so the repo is always the source of truth (no build-time patching).
+#   2. A bare semver tag (no "v" prefix) is created and pushed.
+#   3. The tag push triggers .github/workflows/release.yml, which zips
+#      the component as-is and creates a GitHub Release with auto-generated notes.
+#
+# Usage: ./scripts/bump-version.sh 0.6.0
+
+VERSION="${1:?Usage: $0 <version>}"
+MANIFEST="custom_components/additional_ca/manifest.json"
+
+jq --arg v "$VERSION" '.version = $v' "$MANIFEST" > tmp.json
+mv tmp.json "$MANIFEST"
+
+git add "$MANIFEST"
+git commit -m "chore: bump version to $VERSION"
+git tag "$VERSION"
+git push && git push --tags


### PR DESCRIPTION
Would like to see the manifest version match the github release.
I haven't found a great way to spot check if I copied over the latest changes or not.

thank you